### PR TITLE
#26165: [desktop] Disable window manager close button on the setup project wizard

### DIFF
--- a/python/setup_project/wizard.py
+++ b/python/setup_project/wizard.py
@@ -28,6 +28,7 @@ class SetupProjectWizard(QtGui.QWizard):
     """
     def __init__(self, project, parent=None):
         QtGui.QWizard.__init__(self, parent)
+        self.setWindowFlags((self.windowFlags() | QtCore.Qt.CustomizeWindowHint) & ~QtCore.Qt.WindowCloseButtonHint)
 
         # setup the command wizard from core
         wizard_factory = sgtk.get_command("setup_project_factory")


### PR DESCRIPTION
Disable window manager close button on the setup project wizard in order to prevent from being left with a bad setup.
