### PR TITLE
#29763 Sanitize input to UTF-8 before passing to setup project wizard

### DIFF
--- a/python/setup_project/config_location_page.py
+++ b/python/setup_project/config_location_page.py
@@ -84,9 +84,9 @@ class ConfigLocationPage(BasePage):
 
     def validatePage(self):
         # grab the os paths
-        macosx_path = self.field("config_path_mac")
-        linux_path = self.field("config_path_linux")
-        windows_path = self.field("config_path_win")
+        macosx_path = self.field("config_path_mac").encode("utf-8")
+        linux_path = self.field("config_path_linux").encode("utf-8")
+        windows_path = self.field("config_path_win").encode("utf-8")
 
         if sys.platform == "darwin":
             current_os_path = macosx_path

--- a/python/setup_project/disk_config_page.py
+++ b/python/setup_project/disk_config_page.py
@@ -35,7 +35,7 @@ class DiskConfigPage(BasePage):
         uri = self.field("disk_path")
         wiz = self.wizard()
         try:
-            wiz.set_config_uri(uri)
+            wiz.set_config_uri(uri.encode("utf-8"))
             wiz.ui.disk_errors.setText("")
         except Exception, e:
             wiz.ui.disk_errors.setText(str(e))

--- a/python/setup_project/github_config_page.py
+++ b/python/setup_project/github_config_page.py
@@ -47,7 +47,7 @@ class GithubConfigPage(BasePage):
         wait = WaitScreen("Downloading Config,", "hold on...", parent=self)
         wait.show()
         try:
-            wiz.set_config_uri(uri)
+            wiz.set_config_uri(uri.encode("utf-8"))
             wiz.ui.github_errors.setText("")
         except Exception, e:
             wiz.ui.github_errors.setText(str(e))

--- a/python/setup_project/project_config_page.py
+++ b/python/setup_project/project_config_page.py
@@ -94,7 +94,7 @@ class ProjectConfigPage(BasePage):
         config_uri = os.path.join(self._project_config_path, "config")
         try:
             # test the config and clear errors on success
-            wiz.set_config_uri(config_uri)
+            wiz.set_config_uri(config_uri.encode("utf-8"))
             wiz.ui.project_errors.setText("")
             return True
         except Exception, e:

--- a/python/setup_project/project_name_page.py
+++ b/python/setup_project/project_name_page.py
@@ -83,7 +83,7 @@ class ProjectNamePage(BasePage):
         wiz = self.wizard()
         name = self.field("project_name")
         try:
-            wiz.core_wizard.set_project_disk_name(name)
+            wiz.core_wizard.set_project_disk_name(name.encode("utf-8"))
             self.name_valid = True
             return True
         except Exception, e:

--- a/python/setup_project/storage_locations_page.py
+++ b/python/setup_project/storage_locations_page.py
@@ -175,9 +175,9 @@ class StorageLocationsPage(BasePage):
 
         # grab the path for the operating systems
         current_os_path = str(self._store_path_widgets[current_os].text())
-        mac_path = str(self._store_path_widgets["darwin"].text())
-        windows_path = str(self._store_path_widgets["win32"].text())
-        linux_path = str(self._store_path_widgets["linux2"].text())
+        mac_path = self._store_path_widgets["darwin"].text().encode("utf-8")
+        windows_path = self._store_path_widgets["win32"].text().encode("utf-8")
+        linux_path = self._store_path_widgets["linux2"].text().encode("utf-8")
 
         if self._store_info["defined_in_shotgun"]:
             # see if any shotgun values have changed


### PR DESCRIPTION
By default PyQT/PySide handles text values as unicode. Toolkit expects that any text-like objects are string objects (encoded to UTF-8). When passing these values to the setup project wizard in the Toolkit core, unicode can potentially cause issues.

For example, the `config/core/pipeline_configuration.yml` file stores the project name entered during the project setup process with `!!python/unicode` prepended. This can then propagate issues further inside Toolkit. 

By sanitizing the input before passing it along, we ensure that we don't have these issues.
