### PR TITLE
For SG-5409, Updates path sanitation for browsing and manual entry

### DIFF
--- a/python/setup_project/storage_map_widget.py
+++ b/python/setup_project/storage_map_widget.py
@@ -473,10 +473,17 @@ class StorageMapWidget(QtGui.QWidget):
         there are any concerns about the entered text.
         """
 
-        only_slashes = path.replace("/", "") == "" or path.replace("\\", "") == ""
+        # does the path only contain slashes?
+        only_slashes = path.replace("/", "") == "" or \
+            path.replace("\\", "") == ""
+
+        # does it end in a slash?
         trailing_slash = path.endswith("/") or path.endswith("\\")
 
+        # the name of the storage being edited
         storage_name = str(self.ui.storage_select_combo.currentText())
+
+        # a temp SG path object used for sanitization
         sg_path = ShotgunPath()
 
         # store the edited path in the appropriate path lookup. sanitize first

--- a/python/setup_project/storage_map_widget.py
+++ b/python/setup_project/storage_map_widget.py
@@ -407,7 +407,11 @@ class StorageMapWidget(QtGui.QWidget):
         self.ui.count_lbl.setText("%s of %s" % (num, total))
 
     def _browse_path(self, platform):
-        """Browse and set the path for the supplied os key."""
+        """Browse and set the path for the supplied platform.
+
+        :param platform: A string indicating the platform to associate with the
+            browsed path. Should match the strings returned by ``sys.platform``.
+        """
 
         # create the dialog
         folder_path = QtGui.QFileDialog.getExistingDirectory(
@@ -471,11 +475,13 @@ class StorageMapWidget(QtGui.QWidget):
         """
         Keep track of any path edits as they happen. Keep the user informed if
         there are any concerns about the entered text.
+
+        :param path: The path that has changed.
+        :param platform: The platform the modified path is associated with.
         """
 
         # does the path only contain slashes?
-        only_slashes = path.replace("/", "") == "" or \
-            path.replace("\\", "") == ""
+        only_slashes = path.replace("/", "").replace("\\", "") == ""
 
         # does it end in a slash?
         trailing_slash = path.endswith("/") or path.endswith("\\")


### PR DESCRIPTION
The code has been updated to sanitize any path that is edited in the mapping widget. This includes manual entry and populating a path by browsing. You can see this happening if you attempt to manually enter a `\` for a mac or linux path or a `/` for a windows path. 

There are a couple of caveats when entering paths manually, but none seem terribly annoying. Example, not being to backspace after typing: `C:\` and not correcting paths that only contain `\` or `/` (core's `ShotgunPath` object, which handles sanitation, does not handle these well). Worth doing more testing in QA to see if anything feels terribly wrong. 

Overall though, this feels much better/safer and should help clients avoid entering/saving invalid paths for the various operating systems.