### PR TITLE
SG-17547 Fixes the storage dropdown styling in PySide2.

### DIFF
--- a/python/setup_project/storage_map_page.py
+++ b/python/setup_project/storage_map_page.py
@@ -201,7 +201,7 @@ class StorageMapPage(BasePage):
         for (root_name, root_info) in self._required_roots:
 
             # create the widget and set all the values
-            map_widget = StorageMapWidget(self._storages_model, parent=self)
+            map_widget = StorageMapWidget(self._storages_model, parent=ui.storage_map_area_widget)
             map_widget.root_name = root_name
             map_widget.root_info = root_info
             map_widget.set_count(count, num_roots)


### PR DESCRIPTION
Fixes a black bar at the bottom of the storage drop down list.

The issue was that the StorageMapWidget was not correctly parented, which led to strange styling with a growing black bar at the bottom of the list.