### PR TITLE
SG-19651 fix missing cancel button on failed setup

### DIFF
--- a/python/setup_project/progress_page.py
+++ b/python/setup_project/progress_page.py
@@ -65,16 +65,6 @@ class ProgressPage(BasePage):
         )
 
     def initializePage(self):
-        import sys
-
-        sys.path.append(
-            "/Applications/PyCharm.app/Contents/debug-eggs/pydevd-pycharm.egg"
-        )
-        import pydevd_pycharm
-
-        pydevd_pycharm.settrace(
-            "localhost", port=1234, stdoutToServer=True, stderrToServer=True
-        )
         # disable the cancel and back buttons
         wiz = self.wizard()
         wiz.button(wiz.NextButton).setEnabled(False)

--- a/python/setup_project/progress_page.py
+++ b/python/setup_project/progress_page.py
@@ -65,6 +65,16 @@ class ProgressPage(BasePage):
         )
 
     def initializePage(self):
+        import sys
+
+        sys.path.append(
+            "/Applications/PyCharm.app/Contents/debug-eggs/pydevd-pycharm.egg"
+        )
+        import pydevd_pycharm
+
+        pydevd_pycharm.settrace(
+            "localhost", port=1234, stdoutToServer=True, stderrToServer=True
+        )
         # disable the cancel and back buttons
         wiz = self.wizard()
         wiz.button(wiz.NextButton).setEnabled(False)
@@ -221,8 +231,9 @@ class ProgressPage(BasePage):
         # show the failure icon and message
         wiz = self.wizard()
         wiz.button(wiz.CancelButton).setVisible(True)
-        wiz.setButtonText(wiz.NextButton, "Quit")
         wiz.ui.complete_errors.setText(message)
+
+        wiz.setButtonLayout([wiz.HelpButton, wiz.Stretch, wiz.CancelButton])
 
     def _on_thread_finished(self):
         # since a thread could be calling this make sure we are doing GUI work on the main thread


### PR DESCRIPTION
This was weird, it seemed that it just didn't want to re draw the changes. When on a breakpoint, if I ran the `QCoreApplication.processEvents()` three or found times the changes would actually show.
I found setting the button layout to include the cancel button was enough to show it again.

Previously the next button would get renamed into "Quit" but when pressed it would take you to the setup complete dialog.
I couldn't get this button to re-enable, and after struggling to get it to enable, I decided actually maybe the cancel button it enough and we can just hide the next button.

<img width="754" alt="Screenshot 2020-10-12 at 16 19 31" src="https://user-images.githubusercontent.com/3777228/95763197-a490f580-0ca6-11eb-8ca1-653b27f359a0.png">
