### PR TITLE
SG-19689 Browsed configuration paths on Windows use backslashes

### DIFF
--- a/python/setup_project/config_location_page.py
+++ b/python/setup_project/config_location_page.py
@@ -110,7 +110,7 @@ class ConfigLocationPage(BasePage):
             None,
             QtGui.QFileDialog.ShowDirsOnly | QtGui.QFileDialog.DontConfirmOverwrite,
         )
-        self._path_widget.setText(config_dir)
+        self._path_widget.setText(os.path.normpath(config_dir))
 
     def initializePage(self):
         # setup the default locations


### PR DESCRIPTION
Fixes an issue where browsing to a configuration path on windows would produce a path using forward slashes. When pressing next the validation would fail. It now uses backslashes.